### PR TITLE
point action to push artifact in work directory.

### DIFF
--- a/.github/workflows/helm-chart-publisher.yaml
+++ b/.github/workflows/helm-chart-publisher.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Package and push helm chart
         run: |
           helm package ./chart/${{ env.CHART_NAME }} --version ${{ steps.set-variables.outputs.VERSION }}
-          helm push ./${{ env.CHART_NAME }}/${{ env.CHART_NAME }}-${{ steps.set-variables.outputs.VERSION }}.tgz oci://${{ steps.set-variables.outputs.REPOSITORY }}/charts
+          helm push ${{ github.workspace }}/${{ env.CHART_NAME }}/${{ env.CHART_NAME }}-${{ steps.set-variables.outputs.VERSION }}.tgz oci://${{ steps.set-variables.outputs.REPOSITORY }}/charts
   
   publish-helm-chart:
     permissions:


### PR DESCRIPTION
use `${{ github.workspace }}` to reference the runner's working directory.