### PR TITLE
add dependency on package step

### DIFF
--- a/.github/workflows/helm-chart-publisher.yaml
+++ b/.github/workflows/helm-chart-publisher.yaml
@@ -59,6 +59,9 @@ jobs:
       
     runs-on: ubuntu-latest
 
+    needs:
+      - package-helm-chart
+
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
publish step needs to wait for packaging to complete, otherwise a race condition occurs.