### PR TITLE
remove gh-pages publish action

### DIFF
--- a/.github/workflows/helm-chart-publisher.yaml
+++ b/.github/workflows/helm-chart-publisher.yaml
@@ -47,27 +47,3 @@ jobs:
         run: |
           helm package ./chart/${{ env.CHART_NAME }} --version ${{ steps.set-variables.outputs.VERSION }}
           helm push ${{ github.workspace }}/${{ env.CHART_NAME }}-${{ steps.set-variables.outputs.VERSION }}.tgz oci://${{ steps.set-variables.outputs.REPOSITORY }}/charts
-  
-  publish-helm-chart:
-    permissions:
-      id-token: write
-      packages: write
-      contents: write
-      actions: read
-      deployments: read
-      pull-requests: read
-      
-    runs-on: ubuntu-latest
-
-    needs:
-      - package-helm-chart
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      - name: Publish Helm chart to GitHub Pages
-        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          linting: off


### PR DESCRIPTION
skipping gh-pages chart repository for now.  OCI repo will be sufficient.