### PR TITLE
Modifies unit test to correctly test for registry.k8s.io library image behavior

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,8 +58,9 @@ func generatePatch(registryList []string, specKey string, containerIndex int, aw
 			// split containerImage to find out if it has two or three parts.
 			// if it has three parts, like docker.io/foo/bar, then it is not a library image.
 			// if it has two parts, like docker.io/bar, then it is a library image and needs library injected into the path.
+			// don't do this for registry.k8s.io images, as they don't follow the spec.
 			parts := strings.Split(containerImage, "/")
-			if len(parts) == 2 {
+			if len(parts) == 2 && registry != "registry.k8s.io" {
 				newImage = fmt.Sprintf("%s/%s/library/%s", ecrRegistryHostname, parts[0], parts[1])
 			}
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -422,6 +422,23 @@ func TestGeneratePatch(t *testing.T) {
 			expectedPatchApplied: false,
 			expectedPatch:        nil,
 		},
+		{
+			name:                 "Patch a tagged registry.k8s.io library image with registry prefix",
+			registryList:         []string{"quay.io", "docker.io", "ghcr.io", "registry.k8s.io"},
+			specKey:              "containers",
+			containerIndex:       0,
+			awsAccountId:         "1234567890123",
+			awsRegion:            "us-west-2",
+			containerImage:       "registry.k8s.io/kube-apiserver:v1.30.2",
+			podNamespace:         "default",
+			podGeneratedName:     "mypod-389fw48",
+			expectedPatchApplied: true,
+			expectedPatch: map[string]string{
+				"op":    "replace",
+				"path":  "/spec/containers/0/image",
+				"value": "1234567890123.dkr.ecr.us-west-2.amazonaws.com/registry.k8s.io/kube-apiserver:v1.30.2",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- registry.k8s.io does not add the library path like docker.io does.  this causes issues when rewriting image paths.