### PR TITLE
#134: Add Cert-manager to the list of namespaces to ignore.

### DIFF
--- a/chart/ecr-pull-through/Chart.yaml
+++ b/chart/ecr-pull-through/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/chart/ecr-pull-through/templates/deployment.yaml
+++ b/chart/ecr-pull-through/templates/deployment.yaml
@@ -37,14 +37,14 @@ spec:
             - name: http
               containerPort: 8443
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/chart/ecr-pull-through/values.yaml
+++ b/chart/ecr-pull-through/values.yaml
@@ -8,6 +8,7 @@ webhookNamspaceSelector:
     operator: NotIn
     values:
     - kube-system
+    - cert-manager
 
 useCertManager: true
 ecrPullThrough:


### PR DESCRIPTION
# Changes
- Resolves #134
- Adds simple liveness and readiness probes for ecr-pull-through.
- Adds cert-manger to the default ignored namespaces.